### PR TITLE
Prepare FPWD for Controller Document specification.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1959,19 +1959,19 @@ function baseDecode(sourceEncoding, sourceBase, baseAlphabet) {
         <p>
 The following algorithm specifies how to safely retrieve a verification method,
 such as a cryptographic <a>public key</a>, by using a <a>verification method</a>
-identifier contained in a <a>data integrity proof</a>. Required inputs are a
-<strong><a>data integrity proof</a></strong> (<var>proof</var>) and a set of
-<strong>dereferencing options</strong> (<var>options</var>). A
+identifier. Required inputs are a
+<strong><a>verification method</a></strong> (<var>verificationMethod</var>),
+a <strong><a>proof purpose</a></strong> (<var>proofPurpose</var>), and
+a set of <strong>dereferencing options</strong> (<var>options</var>). A
 <strong>verification method</strong> is produced as output.
         </p>
 
         <ol class="algorithm">
           <li>
-Let <var>vmIdentifier</var> be set to
-<var>proof</var>.<var>verificationMethod</var>.
+Let <var>vmIdentifier</var> be set to <var>verificationMethod</var>.
           </li>
           <li>
-Let <var>vmPurpose</var> be set to <var>proof</var>.<var>proofPurpose</var>.
+Let <var>vmPurpose</var> be set to <var>proofPurpose</var>.
           </li>
           <li>
 If <var>vmIdentifier</var> is not a valid URL, an error MUST be raised and SHOULD

--- a/index.html
+++ b/index.html
@@ -925,7 +925,7 @@ The following sections define several useful <a>verification relationships</a>.
 A <a>controller document</a> MAY include any of these, or other properties, to
 express a specific <a>verification relationship</a>. To maximize global
 interoperability, any such properties used SHOULD be registered in the
-<a href="https://w3c.github.io/vc-specs-dir/#proof">VC Specifications Directory</a>.
+<a href="https://w3c.github.io/vc-specs-dir/#securing-mechanisms">VC Specifications Directory</a>.
           </p>
 
           <section>

--- a/index.html
+++ b/index.html
@@ -299,6 +299,12 @@ will profile the features that it defines,
 requiring and/or recommending the use of some and
 prohibiting and/or deprecating the use of others.
       </p>
+      <p>
+It is expected that other specifications using this specification
+will profile the features that it defines,
+requiring and/or recommending the use of some and
+prohibiting and/or deprecating the use of others.
+      </p>
 
       <section id="conformance">
         <p>

--- a/index.html
+++ b/index.html
@@ -463,10 +463,7 @@ include additional properties.
 <!-- VC-DATA-INTEGRITY-SPECIFIC:
 <a>Verification methods</a> SHOULD be registered
 in the Data Integrity Specification Registries [TBD - DIS-REGISTRIES].
-              </p>
-              <p class="note">
-The `verificationMethod` property is REQUIRED for proofs, unlike controller
-documents, for which it is optional.<!-- See section <a href="#proofs"></a>. -->
+-->
               </p>
 
               <dl>

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
     <script type="text/javascript" class="remove">
       var respecConfig = {
           // specification status (e.g. WD, LCWD, NOTE, etc.). If in doubt use ED.
-          specStatus:           "ED",
+          specStatus:           "FPWD",
 
           // the specification's short name, as in http://www.w3.org/TR/short-name/
           shortName:            "vc-controller-document",
@@ -23,7 +23,7 @@
           //subtitle: "Controller Documents",
 
           // if you wish the publication date to be other than today, set this
-          //publishDate:  "2023-11-07",
+          publishDate:  "2024-05-30",
 
           // if there is a previously published draft, uncomment this and set its YYYY-MM-DD date
           // and its maturity status

--- a/index.html
+++ b/index.html
@@ -114,7 +114,7 @@
           // document unless you know what you're doing. If in doubt ask your friendly neighbourhood
           // Team Contact.
           //wgPatentURI:  "",
-          xref: ["URL", "I18N-GLOSSARY", "INFRA", "VC-DATA-MODEL-2.0"],
+          xref: ["URL", "I18N-GLOSSARY", "INFRA", "?VC-DATA-MODEL-2.0"],
           maxTocLevel: 3,
           /*preProcess: [ ],
           alternateFormats: [ {uri: "diff-20111214.html", label: "diff to previous version"} ],
@@ -361,13 +361,6 @@ order to achieve a particular security goal. These documents are often used
 to specify [=verification methods=], digital signature types,
 their identifiers, and other related properties.<!--  See Section -->
 <!-- [[[#cryptographic-suites]]] for further detail. -->
-          </dd>
-
-          <dt><dfn data-lt="decentralized identifiers|DID|DIDs">decentralized identifier</dfn> (DID)</dt>
-          <dd>
-A globally unique persistent identifier that does not require a centralized
-registration authority and is often generated and/or registered
-cryptographically. The generic format of a is defined in [[?DID-CORE]].
           </dd>
 
           <dt><dfn class="export" data-lt="controller(s)">controller</dfn></dt>
@@ -867,7 +860,7 @@ embedded and its properties can be accessed directly. However, if the value is a
 URL <a data-cite="INFRA#string">string</a>, the <a>verification method</a> has
 been included by reference and its properties will need to be retrieved from
 elsewhere in the <a>controller document</a> or from another <a>controller document</a>. This
-is done by dereferencing the URL and searching the resulting <a>resource</a> for a
+is done by dereferencing the URL and searching the resulting resource for a
 <a>verification method</a> <a data-cite="INFRA#ordered-map">map</a> with an
 `id` property whose value matches the URL.
             </p>
@@ -1013,11 +1006,11 @@ the value of `controller` needs to <a>authenticate</a> with its
             <p>
 The `assertionMethod` <a>verification relationship</a> is used to
 specify how the <a>controller</a> is expected to express claims, such as for
-the purposes of issuing a Verifiable Credential [[?VC-DATA-MODEL-2.0]].
+the purposes of issuing a [=verifiable credential=].
             </p>
 
             <dl>
-              <dt><dfn id="defn-assertionMethod">assertionMethod</dfn></dt>
+              <dt id="defn-assertionMethod">assertionMethod</dt>
               <dd>
 The `assertionMethod` property is OPTIONAL. If present, its associated
 value MUST be a <a data-cite="INFRA#ordered-set">set</a> of one or
@@ -1128,7 +1121,7 @@ authorization to update the <a>controller document</a>.
             </p>
 
             <dl>
-              <dt><dfn id="defn-capabilityInvocation">capabilityInvocation</dfn></dt>
+              <dt id="defn-capabilityInvocation">capabilityInvocation</dt>
               <dd>
 The `capabilityInvocation` property is OPTIONAL. If present, the
 associated value MUST be a <a data-cite="INFRA#ordered-set">set</a> of
@@ -1149,7 +1142,7 @@ message that is placed into the HTTP Headers.
             <p>
 The server providing the HTTP API is the <em>verifier</em> of the capability and
 it would need to verify that the <a>verification method</a> referred to by the
-invoked capability exists in the `<a>capabilityInvocation</a>`
+invoked capability exists in the `capabilityInvocation`
 property of the <a>controller document</a>. The verifier would also check to make sure
 that the action being performed is valid and the capability is appropriate for
 the resource being accessed. If the verification is successful, the server has
@@ -1195,7 +1188,7 @@ to access a specific HTTP API to a subordinate.
             </p>
 
             <dl>
-              <dt><dfn class="lint-ignore" id="defn-capabilityDelegation">capabilityDelegation</dfn></dt>
+              <dt id="defn-capabilityDelegation">capabilityDelegation</dt>
               <dd>
 The `capabilityDelegation` property is OPTIONAL. If present, the
 associated value MUST be a <a data-cite="INFRA#ordered-set">set</a> of
@@ -2197,7 +2190,7 @@ Populated Terminology section.
         </li>
         <li>
 Apply wording updates from VC-JOSE-COSE spec.
-        <li>
+        </li>
       </ul>
 
     </section>

--- a/index.html
+++ b/index.html
@@ -1692,19 +1692,9 @@ The canonical mapping consists of using the lexical-to-value mapping.
       <h2>Algorithms</h2>
 
       <p>
-The algorithms defined below are generalized in that they require a specific
-<a>transformation algorithm</a>, <a>hashing algorithm</a>,
-<a>proof serialization algorithm</a>, and <a>proof verification algorithm</a> to be
-specified by a particular cryptographic suite<!--  (see Section -->
-<!-- <a href="#cryptographic-suites"></a>) -->.
-      </p>
-
-      <p class="issue" title="Verification hash algorithm definition">
-At present the creation of the verification hash is delegated to the
-cryptographic suite specification when generating and verifying a proof. It is
-expected that this algorithm is going to be common to most cryptographic suites.
-It is predicted that the algorithm that generates the verification hash
-will eventually be defined in this specification.
+This section defines algorithms used by this specification including
+instructions on how to base-encode and base-decode values, safely retrieve
+verification methods, and produce processing errors over HTTP channels.
       </p>
 
       <section class="normative">

--- a/index.html
+++ b/index.html
@@ -114,6 +114,7 @@
           // document unless you know what you're doing. If in doubt ask your friendly neighbourhood
           // Team Contact.
           //wgPatentURI:  "",
+          xref: ["URL", "I18N-GLOSSARY", "INFRA", "VC-DATA-MODEL-2.0"],
           maxTocLevel: 3,
           /*preProcess: [ ],
           alternateFormats: [ {uri: "diff-20111214.html", label: "diff to previous version"} ],
@@ -234,7 +235,7 @@
               publisher:  "The IETF OAuth Working Group"
             }
           },
-          postProcess: [restrictRefs],
+          postProcess: [],
           otherLinks: [{
             key: "Related Specifications",
             data: [{
@@ -1590,52 +1591,6 @@ necessary Data Integrity terms that were previously mapped by
           <p>
 This section defines datatypes that are used by this specification.
           </p>
-
-        <section>
-          <h4 id="cryptosuiteString">The `cryptosuiteString` Datatype</h3>
-
-          <p>
-This specification encodes cryptographic suite identifiers as enumerable
-strings, which is useful in processes that need to efficiently encode such
-strings, such as compression algorithms. In environments that support data types
-for string values, such as RDF [[?RDF-CONCEPTS]], cryptographic identifier
-content is indicated using a literal value whose datatype is set to
-`https://w3id.org/security#cryptosuiteString`.
-          </p>
-
-          <p>
-The <code>cryptosuiteString</code> datatype is defined as follows:
-          </p>
-
-          <dl>
-            <dt>The URL denoting this datatype</dt>
-            <dd>
-`https://w3id.org/security#cryptosuiteString`
-            </dd>
-            <dt>The lexical space</dt>
-            <dd>
-The union of all cryptosuite strings, expressed using American Standard Code
-for Information Interchange [[ASCII]] strings, that are defined by the
-collection of all Data Integrity cryptosuite specifications.
-            </dd>
-            <dt>The value space</dt>
-            <dd>
-The union of all cryptosuite types that are expressed using the `cryptosuite`
-property, as defined in Section <a href="#dataintegrityproof"></a>.
-            </dd>
-            <dt>The lexical-to-value mapping</dt>
-            <dd>
-Any element of the lexical space is mapped to the result of parsing it into an
-internal representation that uniquely identifies the cryptosuite type from all
-other possible cryptosuite types.
-            </dd>
-            <dt>The canonical mapping</dt>
-            <dd>
-Any element of the value space is mapped to the corresponding string in the
-lexical space.
-            </dd>
-          </dl>
-        </section>
 
         <section>
           <h4 id="multibase">The `multibase` Datatype</h3>

--- a/index.html
+++ b/index.html
@@ -114,7 +114,7 @@
           // document unless you know what you're doing. If in doubt ask your friendly neighbourhood
           // Team Contact.
           //wgPatentURI:  "",
-          xref: ["URL", "I18N-GLOSSARY", "INFRA", "?VC-DATA-MODEL-2.0"],
+          xref: ["URL", "I18N-GLOSSARY", "INFRA"],
           maxTocLevel: 3,
           /*preProcess: [ ],
           alternateFormats: [ {uri: "diff-20111214.html", label: "diff to previous version"} ],
@@ -1006,7 +1006,8 @@ the value of `controller` needs to <a>authenticate</a> with its
             <p>
 The `assertionMethod` <a>verification relationship</a> is used to
 specify how the <a>controller</a> is expected to express claims, such as for
-the purposes of issuing a [=verifiable credential=].
+the purposes of issuing a
+<a data-cite="?VC-DATA-MODEL-2.0#dfn-verifiable-credential">verifiable credential</a>.
             </p>
 
             <dl>
@@ -1020,8 +1021,9 @@ be embedded or referenced.
             </dl>
 
             <p>
-This property is useful, for example, during the processing of a <a>verifiable
-credential</a> by a verifier.
+This property is useful, for example, during the processing of a
+<a data-cite="?VC-DATA-MODEL-2.0#dfn-verifiable-credential">verifiable credential</a>
+by a verifier.
 <!-- VC-DATA-INTEGRITY-SPECIFIC:
 During verification, a verifier checks to see if a
 <a>verifiable credential</a> contains a proof created by the <a>controller</a>
@@ -1536,7 +1538,8 @@ approaches such as those described above or functionally equivalent mechanisms.
         </p>
         <p>
 Some applications, such as digital wallets, that are capable of holding arbitrary
-<a>verifiable credentials</a> or other data-integrity-protected documents, from
+<a data-cite="?VC-DATA-MODEL-2.0#dfn-verifiable-credential">verifiable credentials</a>
+or other data-integrity-protected documents, from
 any issuer and using any contexts, might need to be able to load externally
 linked resources, such as JSON-LD context files, in production settings. This is
 expected to increase user choice, scalability, and decentralized upgrades in the

--- a/index.html
+++ b/index.html
@@ -250,6 +250,9 @@
             }, {
               value: "Securing Verifiable Credentials using JOSE and COSE",
               href: "https://www.w3.org/TR/vc-jose-cose/"
+            }, {
+              value: "Securing Verifiable Credentials using JOSE and COSE",
+              href: "https://www.w3.org/TR/vc-jose-cose/"
             }]
           }]
       };
@@ -460,7 +463,10 @@ include additional properties.
 <!-- VC-DATA-INTEGRITY-SPECIFIC:
 <a>Verification methods</a> SHOULD be registered
 in the Data Integrity Specification Registries [TBD - DIS-REGISTRIES].
--->
+              </p>
+              <p class="note">
+The `verificationMethod` property is REQUIRED for proofs, unlike controller
+documents, for which it is optional.<!-- See section <a href="#proofs"></a>. -->
               </p>
 
               <dl>

--- a/index.html
+++ b/index.html
@@ -1961,7 +1961,7 @@ The following algorithm specifies how to safely retrieve a verification method,
 such as a cryptographic <a>public key</a>, by using a <a>verification method</a>
 identifier. Required inputs are a
 <strong><a>verification method</a></strong> (<var>verificationMethod</var>),
-a <strong><a>proof purpose</a></strong> (<var>proofPurpose</var>), and
+a <strong>proof purpose</strong> (<var>proofPurpose</var>), and
 a set of <strong>dereferencing options</strong> (<var>options</var>). A
 <strong>verification method</strong> is produced as output.
         </p>
@@ -2104,6 +2104,13 @@ The <a>controller document</a> was malformed. See Section
           <dd>
 The <a>verification method</a> in a <a>controller document</a> was malformed. See Section
 <a href="#retrieve-verification-method"></a>.
+          </dd>
+          <dt id="INVALID_PROOF_PURPOSE_FOR_VERIFICATION_METHOD">INVALID_PROOF_PURPOSE_FOR_VERIFICATION_METHOD (-25)</dt>
+          <dd>
+The [=verification method=] in a [=controller document=] was not
+associated using the expected [=verification relationship=] as expressed in
+the `proofPurpose` property in the proof. See Section
+[[[#retrieve-verification-method]]].
           </dd>
         </dl>
       </section>


### PR DESCRIPTION
This PR readies the FPWD publication of the Controller Documents v1.0 specification (which is effectively a generalized and updated form of the DID Document format). It contains PRs #1, #2, and #3 authored by @selfissued. It does not contain PR #4, which removes all of the authors of the DID Core specification, upon which this document is based. It also contains a number of changes that were needed to fix up all of the broken links and references in the specification.

A static version of the document can be found here:

https://w3c.github.io/vc-controller-document/FPWD/2024-FPWD/