### PR TITLE
Changed the short name

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
           specStatus:           "FPWD",
 
           // the specification's short name, as in http://www.w3.org/TR/short-name/
-          shortName:            "vc-controller-document",
+          shortName:            "controller-document",
 
           // subtitle
           //subtitle: "Controller Documents",


### PR DESCRIPTION
Per the [resolution of the WG](https://www.w3.org/2017/vc/WG/Meetings/Minutes/2024-05-08-vcwg#resolution1), the short name should be `controller-document`. This PR changes the respec header accordingly.