### PR TITLE
Allow for fragment identifier in document.id

### DIFF
--- a/index.html
+++ b/index.html
@@ -2703,7 +2703,7 @@ the document fragment.
 Let <var>documentFragment</var> be `null`.
           </li>
           <li>
-Let <var>controllerDocumentUrl</var> be the result of parsing
+Let <var>canonicalDocumentUrl</var> be the result of parsing
 <var>document</var>.<var>id</var> according to the rules of the URL scheme and extracting
 the primary resource identifier (without the fragment identifier).
           </li>

--- a/index.html
+++ b/index.html
@@ -803,11 +803,14 @@ A [=controlled identifier document=] MUST contain an `id` value in the <em>topmo
             <p>
 The value of the `id` property in the <em>topmost</em>
 <a data-cite="INFRA#ordered-map">map</a> of the [=controlled identifier document=] is
-called the <dfn>base identifier</dfn> for the [=controlled identifier document=]. The URL
+called the <dfn>base identifier</dfn> for the [=controlled identifier document=].
+We call <dfn>primary identifier</dfn> the URL obtained by removing the [=url/fragment=]
+from the [=base identifier=], if any.
+The URL
 for retrieving the current, authoritative [=controlled identifier document=] for a given
 [=identifier=] is called the <dfn>canonical URL</dfn> for the [=controlled identifier
 document=]. Dereferencing the [=canonical URL=] MUST return the current
-authoritative [=controlled identifier document=]. The returned document's [=base
+authoritative [=controlled identifier document=]. The returned document's [=primary
 identifier=] MUST be the same as the [=canonical URL=]; if it is anything else,
 then the returned document is not an authoritative [=controlled identifier document=] and
 the [=identifier=] SHOULD be treated as invalid. Every controlled identifier document is
@@ -2566,7 +2569,12 @@ convey an error type of
 <a href="#INVALID_CONTROLLED_IDENTIFIER_DOCUMENT">INVALID_CONTROLLED_IDENTIFIER_DOCUMENT</a>.
           </li>
           <li>
-If <var>controllerDocument</var>.<var>id</var> does not match the
+Let <var>primaryIdentifier</var> be the result of parsing
+<var>controllerDocument</var>.<var>id</var> according to the rules of the URL scheme and extracting
+the primary resource identifier (without the fragment identifier).
+          </li>
+          <li>
+If <var>primaryIdentifier</var> does not match the
 <var>controllerDocumentUrl</var>, an error MUST be raised and SHOULD
 convey an error type of
 <a href="#INVALID_CONTROLLED_IDENTIFIER_DOCUMENT_ID">INVALID_CONTROLLED_IDENTIFIER_DOCUMENT_ID</a>.
@@ -2589,7 +2597,7 @@ convey an error type of
           </li>
           <li>
 If the absolute URL value of <var>verificationMethod</var>.<var>controller</var>
-does not equal <var>controllerDocumentUrl</var>, an error MUST be raised and
+does not equal <var>controllerDocument</var>.<var>id</var>, an error MUST be raised and
 SHOULD convey an error type of
 <a href="#INVALID_VERIFICATION_METHOD">INVALID_VERIFICATION_METHOD</a>.
           </li>
@@ -2695,8 +2703,9 @@ the document fragment.
 Let <var>documentFragment</var> be `null`.
           </li>
           <li>
-Let <var>canonicalDocumentUrl</var> be the value of
-<var>document</var>.<var>id</var>.
+Let <var>controllerDocumentUrl</var> be the result of parsing
+<var>document</var>.<var>id</var> according to the rules of the URL scheme and extracting
+the primary resource identifier (without the fragment identifier).
           </li>
           <li>
 Let <var>fullyQualifiedFragment</var> be the value of

--- a/index.html
+++ b/index.html
@@ -804,7 +804,7 @@ A [=controlled identifier document=] MUST contain an `id` value in the <em>topmo
 The value of the `id` property in the <em>topmost</em>
 <a data-cite="INFRA#ordered-map">map</a> of the [=controlled identifier document=] is
 called the <dfn>base identifier</dfn> for the [=controlled identifier document=].
-We call <dfn>primary identifier</dfn> the URL obtained by removing the [=url/fragment=]
+The <dfn>primary identifier</dfn> is the URL obtained by removing the [=url/fragment=]
 from the [=base identifier=], if any.
 The URL
 for retrieving the current, authoritative [=controlled identifier document=] for a given


### PR DESCRIPTION
This PR addresses #164 , and extends the current spec without any breaking change (any valid document remains valid).

As outlined in #164, the current spec does not allow the subject identifier to contain a fragment identifier, e.g. `https://example.org/my-cid#me`. This PR extends the conditions under which a Controlled Identifier Document is considered valid:

* before: the canonical URL of the Controlled Identifier Document must be equal to `document.id`
* after: the canonical URL of the Controlled Identifier Document must be equal to the `document.id` *without fragment identifier*

This is especially important for HTTP(S) based CIDs, where the use of a fragment identifier is common practice for distinguishing the document's identifier from the subject's identifier.

With this change, the following CID document, living at `https://example.org/my-cid`, would be valid (while currently it is not).

```json
{
  "@context": "https://www.w3.org/ns/cid/v1",
  "id": "https://example.org/my-cid#me",
  "authentication": [{
      "id": "https://example.org/my-cid#authn-key-123",
      "type": "Multikey",
      "controller": "https://example.org/my-cid#me",
      "publicKeyMultibase": "z6MkmM42vxfqZQsv4ehtTjFFxQ4sQKS2w6WR7emozFAn5cxu"
  }]
}
```
cc @uvdsl


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/cid/pull/168.html" title="Last updated on Jul 6, 2026, 8:03 AM UTC (f88bbb7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/cid/168/bcfdb3e...f88bbb7.html" title="Last updated on Jul 6, 2026, 8:03 AM UTC (f88bbb7)">Diff</a>