### PR TITLE
Add CID alias for controlled identifier document term

### DIFF
--- a/index.html
+++ b/index.html
@@ -529,7 +529,6 @@ as updating a [=controlled identifier document=] or generating a [=proof=] using
 A type of identifier that can be proven to be under the control of an entity.
             </p>
           </dd>
-
 <dt><dfn class="export" data-lt="controlled identifier|CID">controlled identifier</dfn></dt>
 <dd>
 <p>

--- a/index.html
+++ b/index.html
@@ -530,7 +530,7 @@ A type of identifier that can be proven to be under the control of an entity.
             </p>
           </dd>
 
-          <dt><dfn class="export">controlled identifier document</dfn></dt>
+          <dt><dfn class="export" data-lt="controlled identifier document|CID">controlled identifier document</dfn></dt>
           <dd>
             <p>
 A document that contains cryptographic material and lists service endpoints that

--- a/index.html
+++ b/index.html
@@ -530,7 +530,14 @@ A type of identifier that can be proven to be under the control of an entity.
             </p>
           </dd>
 
-          <dt><dfn class="export" data-lt="controlled identifier document|CID">controlled identifier document</dfn></dt>
+<dt><dfn class="export" data-lt="controlled identifier|CID">controlled identifier</dfn></dt>
+<dd>
+<p>
+A type of identifier that can be proven to be under the control of an entity.
+</p>
+</dd>
+
+          <dt><dfn class="export" data-lt="controlled identifier document">controlled identifier document</dfn></dt>
           <dd>
             <p>
 A document that contains cryptographic material and lists service endpoints that


### PR DESCRIPTION
Addresses #170


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/cid/pull/171.html" title="Last updated on Jul 8, 2026, 3:54 PM UTC (8708792)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/cid/171/bcfdb3e...8708792.html" title="Last updated on Jul 8, 2026, 3:54 PM UTC (8708792)">Diff</a>