### PR TITLE
remove duplicate definition

### DIFF
--- a/index.html
+++ b/index.html
@@ -523,19 +523,12 @@ as updating a [=controlled identifier document=] or generating a [=proof=] using
             </p>
           </dd>
 
-          <dt><dfn class="export">controlled identifier</dfn></dt>
+          <dt><dfn class="export" data-lt="controlled identifier|CID">controlled identifier</dfn></dt>
           <dd>
             <p>
 A type of identifier that can be proven to be under the control of an entity.
             </p>
           </dd>
-<dt><dfn class="export" data-lt="controlled identifier|CID">controlled identifier</dfn></dt>
-<dd>
-<p>
-A type of identifier that can be proven to be under the control of an entity.
-</p>
-</dd>
-
           <dt><dfn class="export" data-lt="controlled identifier document">controlled identifier document</dfn></dt>
           <dd>
             <p>


### PR DESCRIPTION
somehow this got defined twice. This PR just removes the duplicate in order to fix echidna.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/brentzundel/cid/pull/173.html" title="Last updated on Jul 13, 2026, 6:51 PM UTC (e2f8358)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/cid/173/a451cb3...brentzundel:e2f8358.html" title="Last updated on Jul 13, 2026, 6:51 PM UTC (e2f8358)">Diff</a>